### PR TITLE
v3.5 Update

### DIFF
--- a/wordle/__init__.py
+++ b/wordle/__init__.py
@@ -1,4 +1,4 @@
 from .wordle import Wordle
 
-def setup(bot):
-    bot.add_cog(Wordle(bot))
+async def setup(bot):
+    await bot.add_cog(Wordle(bot))

--- a/wordle/info.json
+++ b/wordle/info.json
@@ -1,9 +1,9 @@
 {
 	"author": ["JDG"],
-	"bot_version": [3,0,0],
-	"description": "Track and interact with your shared Wordle results.",
+	"min_bot_version": "3.5.0",
+	"description": "Track your Wordle statistics and compete with your friends.",
 	"hidden": false,
-	"install_msg": "Installed Wordle!",
+	"install_msg": "Welcome, specify a Wordle ch with [p]wordlechannel",
 	"short": "A Wordle companion cog.",
 	"tags": ["game", "wordle"]
 }


### PR DESCRIPTION
Closes #15 , caused by `setup()` and `add_cog()` functions enforced to be async by redbot v3.5.0 (see [link](https://docs.discord.red/en/stable/incompatible_changes/3.5.html#cog-package-extension-and-cog-loading-unloading-is-now-asynchronous))

Minor metadata updates as well.