### PR TITLE
[VLR] Watch party voice channel feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Share your wordle results and track your stats!
 | `[p]wordletop` | Get Wordle leaderboards for the server |
 
 ### VLR
-Keep track of the Valorant esports scene!
+Keep track of the Valorant esports scene and hold watch parties!
 
 ![vlr_ex1](https://github.com/jakehlee/JDG-Cogs-V3/assets/1744665/a885b36c-520d-4226-8810-eaa673e104fd)
 ![vlr_ex2](https://github.com/jakehlee/JDG-Cogs-V3/assets/1744665/5d245696-fd01-496c-8952-37d6273ecfd1)
@@ -43,8 +43,7 @@ Keep track of the Valorant esports scene!
 | `[p]vlr results vct [n]` | Get n VCT results |
 | `[p]vlr sub team "team name"` | Subscribe to a Valorant team's matches |
 | `[p]vlr sub event "event name"` | Subscribe to an event's matches |
-| `[p]vlr update` | Force data pull from VLR. Does not trigger notifications (admin) |
-| `[p]vlr vc enable "default voice channel name"` | Enable watch party voice chat creation. Members are moved back to the default channel after the watch party ends. Requires "Move Members" and "Manage Channels" permissions.|
-| `[p]vlr vc disable` | Enable watch party voice chats. Requires "Move Members" and "Manage Channels" permissions. |
-| `[p]vlr vc force [url]` | Forces a watch party to be created if the match was not originally subscribed to. |
-
+| `[p]vlr update` | Force data pull from VLR. (admin) |
+| `[p]vlr vc enable "default voice channel name"` | Enable automatic watch party voice chat creation. Members are moved back to the default VC after the watch party ends. Requires "Move Members" and "Manage Channels" permissions.|
+| `[p]vlr vc disable` | Disable watch party voice chats. Deletes all VCs and stops creating more. Requires "Move Members" and "Manage Channels" permissions. |
+| `[p]vlr vc force [https://vlr.gg/url]` | Forces a watch party to be created if the match was not notified. |

--- a/README.md
+++ b/README.md
@@ -44,3 +44,7 @@ Keep track of the Valorant esports scene!
 | `[p]vlr sub team "team name"` | Subscribe to a Valorant team's matches |
 | `[p]vlr sub event "event name"` | Subscribe to an event's matches |
 | `[p]vlr update` | Force data pull from VLR. Does not trigger notifications (admin) |
+| `[p]vlr vc enable "default voice channel name"` | Enable watch party voice chat creation. Members are moved back to the default channel after the watch party ends. Requires "Move Members" and "Manage Channels" permissions.|
+| `[p]vlr vc disable` | Enable watch party voice chats. Requires "Move Members" and "Manage Channels" permissions. |
+| `[p]vlr vc force [url]` | Forces a watch party to be created if the match was not originally subscribed to. |
+

--- a/vlr/vlr.py
+++ b/vlr/vlr.py
@@ -280,7 +280,7 @@ class VLR(commands.Cog):
         if url not in notified:
             notified.append(url)
             await self.config.guild(ctx.guild).notified.set(notified)
-        
+
     async def _create_vc(self, guild: discord.Guild, url: str, name: str):
         """Create a watch party VC
         
@@ -308,7 +308,7 @@ class VLR(commands.Cog):
         for vc in vc_created:
             if url == vc[0]:
                 this_channel = self.bot.get_channel(vc[1])
-                this_members = this_channels.members
+                this_members = this_channel.members
                 for m in this_members:
                     await m.move_to(vc_default)
                 await this_channel.delete(reason="Match Ended")


### PR DESCRIPTION
`[p] vlr vc enable "Default VC Name"` now enables the watch party feature. The bot will create a voice channel for each match that is notified, and delete it upon match completion (after moving members into the default voice channel). Great for letting the server know who's watching the game, and can be useful if there are multiple matches going on at once!